### PR TITLE
Set fetch-depth to 0 when checking out code

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]


### PR DESCRIPTION
Setting the fetch-depth to 0 when checking out code fetches all history for all branches and tags. I think this should be a valid solution because in the Github Action log files I found that when running the git-revision-date-localized plugin on GitHub Actions it might lead to wrong git revision dates, so we need to set the fetch-depth to 0. 