### PR TITLE
Add instructions for MkDocs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# ofo-docs
+## Contributing to the documentation
 
-Follow these [steps](https://docs.openforestobservatory.org/contributing/docs/) to set up a local documentation environment for the Open Forest Observatory project using MkDocs
+To modify or add to the documentation, please refer to our [instructions for contributing](https://docs.openforestobservatory.org/contributing/docs/).

--- a/README.md
+++ b/README.md
@@ -1,26 +1,3 @@
 # ofo-docs
 
-Follow these steps to set up a local documentation environment for the Open Forest Observatory project using MkDocs.
-
-### Step 1: Create a Conda Environment
-
-First, create a new Conda environment with Python 3.10 and activate it:
-```
-conda create --name docs-env python=3.10
-conda activate docs-env
-```
-
-### Step 2: Install MkDocs and Required Plugins
-```
-pip install mkdocstrings
-pip install mkdocs-material
-pip install mkdocs-nav-weight
-pip install mkdocs-awesome-pages-plugin
-pip install mkdocs-git-revision-date-localized-plugin
-pip install mkdocs-git-committers-plugin
-```
-
-### Step 3: Test Locally
-```
-mkdocs serve
-```
+Follow these [steps](https://docs.openforestobservatory.org/contributing/docs/) to set up a local documentation environment for the Open Forest Observatory project using MkDocs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # ofo-docs
+
+Follow these steps to set up a local documentation environment for the Open Forest Observatory project using MkDocs.
+
+### Step 1: Create a Conda Environment
+
+First, create a new Conda environment with Python 3.10 and activate it:
+```
+conda create --name docs-env python=3.10
+conda activate docs-env
+```
+
+### Step 2: Install MkDocs and Required Plugins
+```
+pip install mkdocstrings
+pip install mkdocs-material
+pip install mkdocs-nav-weight
+pip install mkdocs-awesome-pages-plugin
+pip install mkdocs-git-revision-date-localized-plugin
+pip install mkdocs-git-committers-plugin
+```
+
+### Step 3: Test Locally
+```
+mkdocs serve
+```


### PR DESCRIPTION
In the future, if we add more plugins in `mkdocs.yml` then we will need to add `pip install` instructions for the new plugins.